### PR TITLE
Update icon themes to inherit GhostBSD icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ bin-release/
 # Other files and folders
 .settings/
 
-# Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
-# should NOT be excluded as they contain compiler settings and other important
-# information for Eclipse / Flash Builder.
+.idea
+.vscode

--- a/icons/Qogir-Dark/index.theme
+++ b/icons/Qogir-Dark/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Qogir-Dark
 Comment=Flat and colorful personality icon theme
-Inherits=hicolor,breeze
+Inherits=ghostbsd,hicolor,breeze
 
 # KDE Specific Stuff
 DisplayDepth=32

--- a/icons/Qogir-Light/index.theme
+++ b/icons/Qogir-Light/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Qogir-Light
 Comment=Flat and colorful personality icon theme
-Inherits=hicolor,breeze
+Inherits=ghostbsd,hicolor,breeze
 
 # KDE Specific Stuff
 DisplayDepth=32

--- a/icons/Qogir/index.theme
+++ b/icons/Qogir/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Qogir
 Comment=Flat and colorful personality icon theme
-Inherits=hicolor,breeze
+Inherits=ghostbsd,hicolor,breeze
 
 # KDE Specific Stuff
 DisplayDepth=32


### PR DESCRIPTION
## Summary by Sourcery

Update icon theme configuration files and gitignore entries related to icon themes.

Enhancements:
- Adjust icon theme index files for Qogir, Qogir-Dark, and Qogir-Light to change how icons are inherited or organized.

Chores:
- Update .gitignore patterns related to icon assets or theme files.